### PR TITLE
feat: add a flag to allow disabling Jira without source changes

### DIFF
--- a/config_template.json
+++ b/config_template.json
@@ -35,7 +35,6 @@
         "version": "v0.3.0"
     },
     "jira": {
-        "enabled": true,
         "url": "",
         "project_id": 0,
         "issue_type": 0,

--- a/config_template.json
+++ b/config_template.json
@@ -35,7 +35,8 @@
         "version": "v0.3.0"
     },
     "jira": {
-        "url":"",
+        "enabled": true,
+        "url": "",
         "project_id": 0,
         "issue_type": 0,
         "priority": 0

--- a/src/Gamecure.Core/Configuration/ReadApplicationConfigFile.cs
+++ b/src/Gamecure.Core/Configuration/ReadApplicationConfigFile.cs
@@ -1,4 +1,4 @@
-﻿using Gamecure.Core.Common;
+using Gamecure.Core.Common;
 using Gamecure.Core.Common.Logging;
 using Gamecure.Core.Pipeline;
 
@@ -7,7 +7,7 @@ namespace Gamecure.Core.Configuration;
 public record JiraConfig(string Url, int ProjectId, int IssueType, int Priority);
 public record PlasticConfig(string Repository, string[] Includes, string[] Excludes);
 public record LongtailConfig(string Version);
-public record AppConfig(string ClientId, string Project, string Scope, string TokenUrl, string AuthUrl, string GitCommit, string Container, PlasticConfig Plastic, LongtailConfig Longtail, JiraConfig Jira);
+public record AppConfig(string ClientId, string Project, string Scope, string TokenUrl, string AuthUrl, string GitCommit, string Container, PlasticConfig Plastic, LongtailConfig Longtail, JiraConfig? Jira);
 
 public record AppConfigContext(string ConfigFilename) : Context
 {

--- a/src/Gamecure.Core/Configuration/ValidateApplicationConfig.cs
+++ b/src/Gamecure.Core/Configuration/ValidateApplicationConfig.cs
@@ -37,7 +37,7 @@ public class ValidateApplicationConfig : IMiddleware<AppConfigContext>
 
         if (context.Configuration.Jira is not null && string.IsNullOrWhiteSpace(context.Configuration.Jira.Url))
         {
-            return context with { Failed = true, Reason = $"Jira is enabled, but the required field {nameof(AppConfig.Jira.Url)} has not been set." };
+            return context with { Failed = true, Reason = $"Jira has been configured, but the required field {nameof(AppConfig.Jira.Url)} has not been set." };
         }
 
         return await next(context);

--- a/src/Gamecure.Core/Configuration/ValidateApplicationConfig.cs
+++ b/src/Gamecure.Core/Configuration/ValidateApplicationConfig.cs
@@ -1,4 +1,4 @@
-﻿using Gamecure.Core.Pipeline;
+using Gamecure.Core.Pipeline;
 
 namespace Gamecure.Core.Configuration;
 public class ValidateApplicationConfig : IMiddleware<AppConfigContext>
@@ -34,9 +34,10 @@ public class ValidateApplicationConfig : IMiddleware<AppConfigContext>
         {
             return context with { Failed = true, Reason = $"{nameof(AppConfig.Container)} has not been set." };
         }
-        if (string.IsNullOrWhiteSpace(context.Configuration.Jira.Url))
+
+        if (context.Configuration.Jira is not null && string.IsNullOrWhiteSpace(context.Configuration.Jira.Url))
         {
-            return context with { Failed = true, Reason = $"{nameof(AppConfig.Jira.Url)} has not been set." };
+            return context with { Failed = true, Reason = $"Jira is enabled, but the required field {nameof(AppConfig.Jira.Url)} has not been set." };
         }
 
         return await next(context);

--- a/src/Gamecure.GUI/ViewModels/EditorSync/EditorSyncViewModel.cs
+++ b/src/Gamecure.GUI/ViewModels/EditorSync/EditorSyncViewModel.cs
@@ -192,17 +192,25 @@ internal class EditorSyncViewModel : ViewModelBase
             var appConfig = await configurationService.GetAppConfig() ?? throw new InvalidOperationException("Could not get the AppConfig");
 
             var jira = appConfig.Jira;
-            var querystring = new Querystring()
-                .Param("pid", jira.ProjectId)
-                .Param("issuetype", jira.IssueType)
-                .Param("summary", $"Bug in editor {version.Changeset}: *** ADD BUG TITLE HERE ***")
-                .Param("description", "Summary of the bug:\n\nHow to reproduce the bug:\n")
-                .Param("priority", jira.Priority);
 
-            var result = await ApplicationLauncher.LaunchBrowser(jira.Url, querystring);
-            if (!result)
+            if (jira is not null)
             {
-                Logger.Error("Browser was closed immediately");
+                var querystring = new Querystring()
+                    .Param("pid", jira.ProjectId)
+                    .Param("issuetype", jira.IssueType)
+                    .Param("summary", $"Bug in editor {version.Changeset}: *** ADD BUG TITLE HERE ***")
+                    .Param("description", "Summary of the bug:\n\nHow to reproduce the bug:\n")
+                    .Param("priority", jira.Priority);
+
+                var result = await ApplicationLauncher.LaunchBrowser(jira.Url, querystring);
+                if (!result)
+                {
+                    Logger.Error("Browser was closed immediately");
+                }
+            }
+            else
+            {
+                Logger.Error("There is no configured reporting method");
             }
         });
 
@@ -229,7 +237,7 @@ internal class EditorSyncViewModel : ViewModelBase
             {
                 return;
             }
-            
+
             // Run until it crashes or the app is closed.
             while (true)
             {


### PR DESCRIPTION
### Summary
This PR allows users to disable the Jira requirement with a config file change rather than modifying the source by adding an `enabled` flag. This PR is a short term fix to the bigger question on how this functionality is restructured to provide other issue trackers. This PR also makes the error for a missing Jira URL more informative than "Url is missing".

### How to test?
If you set `jira.enabled` to false in `config.json` and leave `jira.url` to an empty string, the application should not error during set up.