### PR TITLE
Remove Jira config if no values are set

### DIFF
--- a/src/Gamecure.BuildTool/Configuration/SetConfigValues.cs
+++ b/src/Gamecure.BuildTool/Configuration/SetConfigValues.cs
@@ -1,4 +1,5 @@
 ﻿using Gamecure.Core.Common.Logging;
+using Gamecure.Core.Configuration;
 using Gamecure.Core.Pipeline;
 
 namespace Gamecure.BuildTool.Configuration;
@@ -23,12 +24,15 @@ internal class SetConfigValues : IMiddleware<ConfigContext>
             {
                 Repository = GetValue(appConfig.Plastic.Repository, context.PlasticRepository)
             },
-            GitCommit = GetValue(appConfig.GitCommit, context.GitCommit)
+            GitCommit = GetValue(appConfig.GitCommit, context.GitCommit),
+            Jira = GetJiraConfig(appConfig.Jira)
         };
+
 
         return await next(context with { AppConfig = appConfig });
 
 
         static string GetValue(string currentValue, string? newValue) => string.IsNullOrWhiteSpace(newValue) ? currentValue : newValue;
+        static JiraConfig? GetJiraConfig(JiraConfig? config) => string.IsNullOrEmpty(config?.Url) ? null : config;
     }
 }

--- a/src/Gamecure.BuildTool/Configuration/ValidateConfig.cs
+++ b/src/Gamecure.BuildTool/Configuration/ValidateConfig.cs
@@ -1,4 +1,5 @@
 ﻿using Gamecure.Core.Common.Logging;
+using Gamecure.Core.Configuration;
 using Gamecure.Core.Pipeline;
 
 namespace Gamecure.BuildTool.Configuration;
@@ -35,6 +36,11 @@ internal class ValidateConfig : IMiddleware<ConfigContext>
         if (string.IsNullOrWhiteSpace(context.AppConfig?.Container))
         {
             return context with { Failed = true, Reason = "Must specify a Google Storage Container" };
+        }
+
+        if (context.AppConfig.Jira is null)
+        {
+            Logger.Warning($"{nameof(AppConfig.Jira)} is null, jira integration will be disabled.");
         }
 
         return await next(context);


### PR DESCRIPTION
### Summary
Remove the Jira entry in the config.json generated by the build tool if the Url is empty.

### How to test?
Generate a new config.json and run Gamecure. It should not give an error on the second step after choosing a workspace. (needs a clean slate without any previous configuration)